### PR TITLE
Make highlight theme configurable

### DIFF
--- a/HighlightjsIntegration.class.php
+++ b/HighlightjsIntegration.class.php
@@ -4,7 +4,17 @@ class HighlightjsIntegration
 {
     public static function onBeforePageDisplay(OutputPage &$out, Skin &$skin)
     {
+        global $wgHighlightJsIntegrationTheme, $wgExtensionAssetsPath;
+
+        $theme = $wgHighlightJsIntegrationTheme;
+        if ( ! is_string($wgHighlightJsIntegrationTheme) || strlen($wgHighlightJsIntegrationTheme) < 1) {
+            $theme = 'vs2015';
+        }
+
         $out->addModules('ext.HighlightjsIntegration');
+
+        $out->addStyle($wgExtensionAssetsPath . '/Highlightjs_Integration/highlight/styles/' . $theme . '.min.css');
+
         return true;
     }
 

--- a/extension.json
+++ b/extension.json
@@ -30,8 +30,7 @@
                 "init.js"
             ],
             "styles": [
-                "custom.css",
-                "highlight/styles/vs2015.min.css"
+                "custom.css"
             ],
             "targets": [
                 "desktop",
@@ -55,7 +54,8 @@
             "xaml": "xml",
             "mediawiki": "markdown",
             "asp": "html"
-        }
+        },
+        "HighlightJsIntegrationTheme": "vs2015"
     },
     "manifest_version": 1
 }


### PR DESCRIPTION
The default theme „vs2015“ can be overriden using the config variable

	$wgHighlightJsIntegrationTheme

in LocalSettings.php